### PR TITLE
live projects section

### DIFF
--- a/portfolio/components/LiveProjects.tsx
+++ b/portfolio/components/LiveProjects.tsx
@@ -1,0 +1,39 @@
+import { Button } from "@material-tailwind/react";
+import { FaExternalLinkAlt } from "react-icons/fa";
+
+export function LiveProjects() {
+  return (
+    <div className="mt-4 sm:mb-8">
+        <h2 className="text-2xl font-bold mb-3">Live Projects 🚀</h2>
+        <div className="flex items-center gap-4">
+            <a href="https://get-smart.justinklein.ca" target="_blank" rel="noopener noreferrer">
+                <Button 
+                    variant="outlined"
+                    className="flex items-center gap-2 border border-white text-white rounded-md px-2 py-2 hover:bg-white/10 hover:translate-x-1 transition-all duration-300 focus:ring-0 normal-case text-sm font-medium tracking-wide"
+                >
+                    <span>Get Smart!</span>
+                    <FaExternalLinkAlt className="h-4 w-4" />
+                </Button>
+            </a>
+            <a href="https://get-quizzed.justinklein.ca" target="_blank" rel="noopener noreferrer">
+                <Button 
+                    variant="outlined"
+                    className="flex items-center gap-2 border border-white text-white rounded-md px-2 py-2 hover:bg-white/10 hover:translate-x-1 transition-all duration-300 focus:ring-0 normal-case text-sm font-medium tracking-wide"
+                >
+                    <span>Get Quizzed!</span>
+                    <FaExternalLinkAlt className="h-4 w-4" />
+                </Button>
+            </a>
+            <a href="https://farm-games.justinklein.ca" target="_blank" rel="noopener noreferrer">
+                <Button 
+                    variant="outlined"
+                    className="flex items-center gap-2 border border-white text-white rounded-md px-2 py-2 hover:bg-white/10 hover:translate-x-1 transition-all duration-300 focus:ring-0 normal-case text-sm font-medium tracking-wide"
+                >
+                    <span>Farm Games</span>
+                    <FaExternalLinkAlt className="h-4 w-4" />
+                </Button>
+            </a>
+        </div>
+    </div>
+  );
+}    

--- a/portfolio/sections/HeroSection.tsx
+++ b/portfolio/sections/HeroSection.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { LiveProjects } from "@/components/LiveProjects";
 import { SocialButtons } from "@/components/SocialButtons";
 import Image from "next/image";
 export function HeroSection() {
@@ -10,6 +11,7 @@ export function HeroSection() {
         <h3 className="text-1xl whitespace-nowrap shrink-0 mb-4">I'm a 24 yo software developer from Toronto 🇨🇦</h3>
         <h2 className="text-1xl font-semibold mb-8">I build cloud-native, full stack applications.</h2>
         <SocialButtons />
+        <LiveProjects />
       </div>
       <div className="grid-column">
         <Image


### PR DESCRIPTION
- Added Live Projects section in the hero page; it made sense to put it there. The idea for this wasn't to bombard a user with a detailed description of each project, but to give them quick access to shipped projects, which, in my opinion, would win trust as proof of deployed work.